### PR TITLE
Make Laration easy to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,13 @@ If no argument is given to list it will display all variables at once.
 
 # Installation
 
-- Inside your composer.json add the following dependency
+- Require Laration with composer
 
 ```
-{
-	"marabesi/laration": "^1.0"
-}
+composer require marabesi/laration
 ```
 
-- Update yor project
-
-```
-composer update
-```
-
-- Add Laration class to your available commands, open the file **app/Console/Kernel.php** and add the following line on ```$commands``` array
-
-``` php
-protected $commands = [
-    // Commands\Inspire::class,
-    \Marabesi\Laration::class, // Add this line
-];
-```
+Done, Laration will be add to your project by [Laravel's 5.5 Package Auto-Discovery](https://laravel.com/docs/5.5/packages#package-discovery).
 
 # Available commands
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If no argument is given to list it will display all variables at once.
 
 ```
 composer require marabesi/laration
-=======
 ```
 
 Done, Laration will be add to your project by [Laravel's 5.5 Package Auto-Discovery](https://laravel.com/docs/5.5/packages#package-discovery).

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,16 @@
         }
     ],
     "require": {},
-	"autoload" : {
+    "autoload" : {
 		"psr-4": {
 			"Marabesi\\": "src"
-		}	
-	}
+		}
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Marabesi\\ServiceProvider"
+            ]
+        }
+    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Marabesi;
+
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+
+class ServiceProvider extends BaseServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Laration::class,
+            ]);
+        }
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR makes Laration installation easier.

By adding a [ServiceProvider](https://laravel.com/docs/5.5/packages#service-providers), loading `Laration` command class in [boot method](https://laravel.com/docs/5.5/packages#commands) and adding [Laravel's 5.5 Package Discovery section in composer.json](https://laravel.com/docs/5.5/packages#package-discovery), with a simple `composer require marabesi/laration`, the package is read to use.

Also, update the `Installation` section in `README.md` :smile: